### PR TITLE
Additions to f5 new-stack deployment:

### DIFF
--- a/Deploy_via_PS.ps1
+++ b/Deploy_via_PS.ps1
@@ -1,0 +1,62 @@
+## Script parameters being asked for below match to parameters in the azuredeploy.json file, otherwise pointing to the ##
+## azuredeploy.parameters.json file for values to use.  Some options below are mandatory, some (such as region) can    ##
+## be supplied inline when running this script but if they aren't then the default will be used as specified below.    ##
+## Example Command: .\Deploy_via_PS.ps1 -adminUsername azureuser -authenticationType password -adminPasswordOrKey <value> -dnsLabel <value> -instanceName f5vm01 -numberOfExternalIps 1 -enableNetworkFailover Yes -internalLoadBalancerType Per-protocol -internalLoadBalancerProbePort 3456 -instanceType Standard_DS3_v2 -imageName AllTwoBootLocations -bigIpVersion 15.0.100000 -bigIpModules ltm:nominal -licenseKey1 <value> -licenseKey2 <value> -vnetAddressPrefix 10.0 -declarationUrl NOT_SPECIFIED -ntpServer 0.pool.ntp.org -timeZone UTC -customImage OPTIONAL -allowUsageAnalytics Yes -resourceGroupName <value>
+
+param(
+
+  [string] [Parameter(Mandatory=$True)] $adminUsername,
+  [string] [Parameter(Mandatory=$True)] $authenticationType,
+  [string] [Parameter(Mandatory=$True)] $adminPasswordOrKey,
+  [string] [Parameter(Mandatory=$True)] $dnsLabel,
+  [string] [Parameter(Mandatory=$True)] $instanceName,
+  [string] [Parameter(Mandatory=$True)] $numberOfExternalIps,
+  [string] [Parameter(Mandatory=$True)] $enableNetworkFailover,
+  [string] [Parameter(Mandatory=$True)] $internalLoadBalancerType,
+  [string] [Parameter(Mandatory=$True)] $internalLoadBalancerProbePort,
+  [string] [Parameter(Mandatory=$True)] $instanceType,
+  [string] [Parameter(Mandatory=$True)] $imageName,
+  [string] [Parameter(Mandatory=$True)] $bigIpVersion,
+  [string] [Parameter(Mandatory=$True)] $bigIpModules,
+  [string] [Parameter(Mandatory=$True)] $licenseKey1,
+  [string] [Parameter(Mandatory=$True)] $licenseKey2,
+  [string] [Parameter(Mandatory=$True)] $vnetAddressPrefix,
+  [string] [Parameter(Mandatory=$True)] $declarationUrl,
+  [string] [Parameter(Mandatory=$True)] $ntpServer,
+  [string] [Parameter(Mandatory=$True)] $timeZone,
+  [string] [Parameter(Mandatory=$True)] $customImage,
+  [string] $restrictedSrcAddress = "*",
+  $tagValues = '{"application": "APP", "cost": "COST", "environment": "ENV", "group": "GROUP", "owner": "OWNER"}',
+  [string] [Parameter(Mandatory=$True)] $allowUsageAnalytics,
+  [string] [Parameter(Mandatory=$True)] $resourceGroupName,
+  [string] $region = "West US",
+  [string] $templateFilePath = "azuredeploy.json",
+  [string] $parametersFilePath = "azuredeploy.parameters.json"
+)
+
+Write-Host "Disclaimer: Scripting to Deploy F5 Solution templates into Cloud Environments are provided as examples. They will be treated as best effort for issues that occur, feedback is encouraged." -foregroundcolor green
+Start-Sleep -s 3
+
+# Connect to Azure, right now it is only interactive login
+try {
+    Write-Host "Checking if already logged in!"
+    Get-AzureRmSubscription | Out-Null
+    Write-Host "Already logged in, continuing..."
+    }
+    catch {
+      Write-Host "Not logged in, please login..."
+      Login-AzureRmAccount
+    }
+
+# Create Resource Group for ARM Deployment
+New-AzureRmResourceGroup -Name $resourceGroupName -Location "$region"
+
+$adminPasswordOrKeySecure = ConvertTo-SecureString -String $adminPasswordOrKey -AsPlainText -Force
+
+(ConvertFrom-Json $tagValues).psobject.properties | ForEach -Begin {$tagValues=@{}} -process {$tagValues."$($_.Name)" = $_.Value}
+
+# Create Arm Deployment
+$deployment = New-AzureRmResourceGroupDeployment -Name $resourceGroupName -ResourceGroupName $resourceGroupName -TemplateFile $templateFilePath -TemplateParameterFile $parametersFilePath -Verbose -adminUsername $adminUsername -authenticationType $authenticationType -adminPasswordOrKey $adminPasswordOrKeySecure -dnsLabel $dnsLabel -instanceName $instanceName -numberOfExternalIps $numberOfExternalIps -enableNetworkFailover $enableNetworkFailover -internalLoadBalancerType $internalLoadBalancerType -internalLoadBalancerProbePort $internalLoadBalancerProbePort -instanceType $instanceType -imageName $imageName -bigIpVersion $bigIpVersion -bigIpModules $bigIpModules -licenseKey1 $licenseKey1 -licenseKey2 $licenseKey2 -vnetAddressPrefix $vnetAddressPrefix -declarationUrl $declarationUrl -ntpServer $ntpServer -timeZone $timeZone -customImage $customImage -restrictedSrcAddress $restrictedSrcAddress -tagValues $tagValues -allowUsageAnalytics $allowUsageAnalytics 
+
+# Print Output of Deployment to Console
+$deployment

--- a/azuredeploy.parameters.json
+++ b/azuredeploy.parameters.json
@@ -1,0 +1,81 @@
+{
+    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "7.0.3.0",
+    "parameters": {
+        "adminUsername": {
+            "value": "azureuser"
+        },
+        "authenticationType": {
+            "value": "password"
+        },
+        "adminPasswordOrKey": {
+            "value": ""
+        },
+        "dnsLabel": {
+            "value": ""
+        },
+        "instanceName": {
+            "value": "f5vm01"
+        },
+        "numberOfExternalIps": {
+            "value": 1
+        },
+        "enableNetworkFailover": {
+            "value": "Yes"
+        },
+        "internalLoadBalancerType": {
+            "value": "All-protocol"
+        },
+        "internalLoadBalancerProbePort": {
+            "value": "3456"
+        },
+        "instanceType": {
+            "value": "Standard_DS3_v2"
+        },
+        "imageName": {
+            "value": "AllTwoBootLocations"
+        },
+        "bigIpVersion": {
+            "value": "15.0.100000"
+        },
+        "bigIpModules": {
+            "value": "ltm:nominal"
+        },
+        "licenseKey1": {
+            "value": ""
+        },
+        "licenseKey2": {
+            "value": ""
+        },
+        "vnetAddressPrefix": {
+            "value": "10.0"
+        },
+        "declarationUrl": {
+            "value": "NOT_SPECIFIED"
+        },
+        "ntpServer": {
+            "value": "0.pool.ntp.org"
+        },
+        "timeZone": {
+            "value": "UTC"
+        },
+        "customImage": {
+            "value": "OPTIONAL"
+        },
+        "restrictedSrcAddress": {
+            "value": "*"
+        },
+        "tagValues": {
+            "value": {
+                "application": "APP",
+                "cost": "COST",
+                "environment": "ENV",
+                "group": "GROUP",
+                "owner": "OWNER"
+            }
+        },
+        "allowUsageAnalytics": {
+            "value": "Yes"
+        }
+    }
+}

--- a/templates/azuredeploy-bigip.json
+++ b/templates/azuredeploy-bigip.json
@@ -86,7 +86,7 @@
                 "All-protocol",
                 "DO_NOT_USE"
             ],
-            "defaultValue": "Per-protocol",
+            "defaultValue": "All-protocol",
             "metadata": {
                 "description": "Specify a the type of internal Azure load balancer to deploy. Note: As of the initial release of this template, the all-protocol Azure load balancer is in public preview. Please ensure that this feature is enabled before selecting **All-protocol**."
             },
@@ -238,6 +238,13 @@
             },
             "type": "string"
         },
+        "restrictedSrcAddressApp": {
+            "defaultValue": "*",
+            "metadata": {
+                "description": "This field restricts application access to a specific network or address. Enter an IP address or address range in CIDR notation, or asterisk for all sources"
+            },
+            "type": "string"
+        },
         "tagValues": {
             "defaultValue": {
                 "application": "APP",
@@ -359,6 +366,7 @@
         },
         "subscriptionID": "[subscription().subscriptionId]",
         "resourceGroupName": "[resourceGroup().name]",
+        "routeTableName": "RouteToIntLB",
         "singleQuote": "'",
         "f5CloudLibsTag": "v4.11.0",
         "f5CloudLibsAzureTag": "v2.10.0",
@@ -418,6 +426,7 @@
         "extSubnetId": "[concat(variables('vnetId'), '/subnets/', variables('extsubnetName'))]",
         "routeCmd": "route",
         "intSubnetName": "internal",
+        "appSubnetName": "appSubnet",
         "intSubnetPrivateAddress": "[concat(parameters('vnetAddressPrefix'), '.3.4')]",
         "intNicName": "[concat(variables('dnsLabel'), '-int')]",
         "intSubnetId": "[concat(variables('vnetId'), '/subnets/', variables('intsubnetName'))]",
@@ -438,6 +447,7 @@
         "tmmRouteGw": "[concat(parameters('vnetAddressPrefix'), '.2.1')]",
         "extSubnetPrefix": "[concat(parameters('vnetAddressPrefix'), '.2.0/24')]",
         "intSubnetPrefix": "[concat(parameters('vnetAddressPrefix'), '.3.0/24')]",
+        "appSubnetPrefix": "[concat(parameters('vnetAddressPrefix'), '.4.0/24')]",
         "numberOfExternalIps": "[parameters('numberOfExternalIps')]",
         "backEndAddressPoolArray": [
             {
@@ -516,6 +526,24 @@
         "installCustomConfig": "[concat(variables('singleQuote'), '#!/bin/bash\n', variables('customConfig'), variables('singleQuote'))]"
     },
     "resources": [
+        {
+            "type": "Microsoft.Network/routeTables",
+            "name": "[variables('routeTableName')]",
+            "apiVersion": "[variables('networkApiVersion')]",
+            "location": "[variables('location')]",
+            "properties": {
+                "routes": [
+                {
+                    "name": "DefaultRouteToIntLB",
+                    "properties": {
+                    "addressPrefix": "0.0.0.0/0",
+                    "nextHopType": "VirtualAppliance",
+                    "nextHopIpAddress": "[variables('internalLoadBalancerAddress')]"
+                    }
+                }
+                ]
+            }
+        },
         {
             "apiVersion": "[variables('networkApiVersion')]",
             "sku": {
@@ -602,6 +630,9 @@
         },
         {
             "apiVersion": "[variables('networkApiVersion')]",
+            "dependsOn": [
+                "[concat('Microsoft.Network/routeTables/', variables('routeTableName'))]"
+            ],
             "location": "[variables('location')]",
             "name": "[variables('virtualNetworkName')]",
             "properties": {
@@ -627,6 +658,15 @@
                         "name": "[variables('intSubnetName')]",
                         "properties": {
                             "addressPrefix": "[variables('intSubnetPrefix')]"
+                        }
+                    },
+                                        {
+                        "name": "[variables('appSubnetName')]",
+                        "properties": {
+                            "routeTable": {
+                                "id": "[resourceId('Microsoft.Network/routeTables', variables('routeTableName'))]"
+                            },
+                            "addressPrefix": "[variables('appSubnetPrefix')]"
                         }
                     }
                 ]
@@ -932,7 +972,36 @@
             "location": "[variables('location')]",
             "name": "[concat(variables('dnsLabel'), '-ext-nsg')]",
             "properties": {
-                "securityRules": []
+                "securityRules": [
+                    {
+                        "name": "ext_allow_http",
+                        "properties": {
+                            "access": "Allow",
+                            "description": "",
+                            "destinationAddressPrefix": "*",
+                            "destinationPortRange": "80",
+                            "direction": "Inbound",
+                            "priority": 101,
+                            "protocol": "Tcp",
+                            "sourceAddressPrefix": "[parameters('restrictedSrcAddressApp')]",
+                            "sourcePortRange": "*"
+                        }
+                    },
+                    {
+                        "name": "ext_allow_https",
+                        "properties": {
+                            "access": "Allow",
+                            "description": "",
+                            "destinationAddressPrefix": "*",
+                            "destinationPortRange": "443",
+                            "direction": "Inbound",
+                            "priority": 102,
+                            "protocol": "Tcp",
+                            "sourceAddressPrefix": "[parameters('restrictedSrcAddressApp')]",
+                            "sourcePortRange": "*"
+                        }
+                    }
+                ]
             },
             "tags": "[if(empty(variables('tagValues')), json('null'), variables('tagValues'))]",
             "type": "Microsoft.Network/networkSecurityGroups"
@@ -973,7 +1042,7 @@
                         "Name": "external-access",
                         "properties": {
                             "backendAddressPool": {
-                                "id": "[concat(resourceId('Microsoft.Network/loadBalancers', variables('externalLoadBalancerName')), '/backendAddressPools/loadBalancerMgmtBackEnd')]"
+                                "id": "[concat(resourceId('Microsoft.Network/loadBalancers', variables('externalLoadBalancerName')), '/backendAddressPools/loadBalancerBackEnd')]"
                             },
                             "backendPort": 443,
                             "frontendIPConfiguration": {


### PR DESCRIPTION
- changed default int lb rule type from per-protocol to all-protocol
- allowed tcp 80 and 443 inbound on extNSG
- added a 4th subnet
- added a UDR and attached to 4th subnet
- edited default backend pool to be dataplane IP addresses on Ext LB